### PR TITLE
Change oas versions and updates paths for deployed spec files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 - Documentation(ReDoc): https://developer.timezynk.com/
 - SwaggerUI: https://developer.timezynk.com/swagger-ui/
 - Look full spec:
-    + JSON https://developer.timezynk.com/swagger.json
-    + YAML https://developer.timezynk.com/swagger.yaml
+    + JSON https://developer.timezynk.com/openapi.json
+    + YAML https://developer.timezynk.com/openapi.yaml
 - Preview spec version for branch `[branch]`: http://developer.timezynk.com/preview/[branch]
 
 **Warning:** All above links are updated only after Travis CI finishes deployment

--- a/spec/components/schemas/IntegrationModule.yaml
+++ b/spec/components/schemas/IntegrationModule.yaml
@@ -1,6 +1,8 @@
 type: object
 properties:
-  id: string
+  id: 
+    type: string
+    description: Id of the integration
   name:
     type: string
     description: Name of the integration

--- a/spec/components/securitySchemes/TZApiAuth.yaml
+++ b/spec/components/securitySchemes/TZApiAuth.yaml
@@ -1,4 +1,5 @@
 type: oauth2
+scheme: bearer
 description: OAuth2 API authentication
 flows:
   authorizationCode:

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.0.2
 info:
   title: Timezynk API
   description: API for Timezynk scheduling system


### PR DESCRIPTION
Version 3.0.2 works better if you want to import the spec into insomnia.