### PR TITLE
Possible API design for repeating entities

### DIFF
--- a/spec/components/schemas/RepeatingTemplate.yaml
+++ b/spec/components/schemas/RepeatingTemplate.yaml
@@ -1,0 +1,50 @@
+allOf:
+  - $ref: "#/components/schemas/BasicObject"
+  - properties:
+      title:
+        type: string
+        description: Template title.
+        example: "Template Title"
+      start: 
+        type: string
+        format: date
+        description: Starting date of template.
+        example: "2020-04-24"
+      end: 
+        type: string
+        format: date
+        description: Ending date of template. Will repeat indefinitely if set to null.
+        example: "2020-04-30"
+      type:
+        type: string
+        enum: ["shift", "timereport", "availability"]
+      item-template:
+        description: Template to be used for each occurrence in the repetition. Start and end will be overwritten.
+        oneOf:
+          - $ref: '#/components/schemas/Shift'
+          - $ref: '#/components/schemas/Availability'
+          - $ref: '#/components/schemas/Timereport'
+      length: 
+        type: integer
+        description: Interval length 
+        example: 7
+      occurrences: 
+        type: array
+        description: On which days in the interval the availabilities should occur. 
+        example: [0, 5, 6]
+        items: 
+          type: integer
+      deleted-ids: 
+        type: array
+        description: List of deleted ids which should not be included in generated availabilities
+        example: ["60754bd1269f1c2a68b43ba2", "60754be52f7d2d33958066c2"]
+        read-only: true
+        items: 
+          type: integer
+
+  - required:
+    - title
+    - start
+    - item
+    - length
+    - occurrences

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -10,6 +10,8 @@ tags:
     description: Endpoints for authentication and configuration
   - name: Availability
     description: Fetching and updating availability
+  - name: Repeating Templates
+    description: Fetching and updating repeating templates
   - name: Invoice
     description: Fetching, updating and creating invoices
   - name: Invoice rows

--- a/spec/paths/repeating-templates.yaml
+++ b/spec/paths/repeating-templates.yaml
@@ -1,0 +1,26 @@
+get:
+  summary: Fetch repeating templates
+  tags:
+    - Repeating Templates
+  responses:
+    200:
+      description: Array of templates.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/RepeatingTemplate"
+post:
+  summary: Create repeating template
+  tags:
+    - Repeating Templates
+  responses:
+    200:
+      description: The created template
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/RepeatingTemplate"

--- a/spec/paths/repeating-templates@templateId.yaml
+++ b/spec/paths/repeating-templates@templateId.yaml
@@ -1,0 +1,32 @@
+get:
+  summary: Fetch repeating template by id
+  parameters:
+    - name: templateId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: ObjectId
+  tags:
+    - Repeating Templates
+  responses:
+    200:
+      description: Repeating template.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/RepeatingTemplate"
+delete:
+  summary: Delete repeating template
+  parameters:
+    - name: templateId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: ObjectId
+  tags:
+    - Repeating Templates
+  responses:
+    200:
+      description: Delete successful


### PR DESCRIPTION
**Proposal 2**

PR https://github.com/TimeZynk/timezynk-api-spec/pull/57

Schema  

```javascript
{
  // default fields
  "id": "5dde7024eded8872705aabcd",
  "vid": "5dde7024eded8872705aabce",
  "company-id": "5dde7024eded8872705aabcf",
  "created": 1558604010307,
  "created-by": "5dde7024eded8872705aabd0",
  "valid-from": 1558604030403,
  "valid-to": 1558604030455,
  "changed-by": "5dde7024eded8872705aabd1",
  "archived": null,

  // Schema fields
  "title": "Template Title",
  "start": "2020-04-24",
  "end": "2020-04-30",
  "type": "shift",
  "item-template": {
    // In this case availability, could also shift or timereport
    "user-id": "6076dd23136a5045e9ac8826",
    "available": true,
    "title": "some title",
  },
  "length": 7,
  "occurrences": [ 0, 5, 6 ],
  "deleted-ids": [
    "60754bd1269f1c2a68b43ba2",
    "60754be52f7d2d33958066c2"
  ]
}
```

_Support infinite repetitions._  
`start` is required, but `end` is optional. If `end` is unset or `null` the availability template should be applied indefinitely.  

_Stop repetition and delete all future instances._  
If `end` date is set, then the availability template should only by applied until end date.

_Support repeating every 1,2,3,4,5,nth day or 1,2,3,4,5,nth week._  
Use `length` to define the length of the interval, and `occurrences` to define on which days the availabilities should be created. Usage will be similar to Work hours schedules.

_Modifying or deleting single instances that are part of a repetition._  
Modifying a single instance should be done by creating a new availability instance, and its id should be included in the templates `deleted-ids`. Also when deleting an a single instance/occurrence from the template, the id of the deleted instance should be included in `deleted-ids`.

_Select between applying change to all future items or not._  
When updating all future events we should end the current template (set `end` date) and create a new template. I think `length` and `occurrences` should be write-once.

_Pros_  
Does support multiple entities e.g. `shifts`, `availabilities` and `timereports`